### PR TITLE
Fix google sign in error.

### DIFF
--- a/app/assets/javascripts/password.js
+++ b/app/assets/javascripts/password.js
@@ -1,10 +1,10 @@
 $(document).on('turbolinks:load', function() {
   if ($('body').hasClass('users-new')) {
-    $('#user_password').focus(function(e) {
+    $('#registration_password').focus(function(e) {
       $('.passwordRules').removeClass('hidden')
     })
 
-    $('#user_password').keyup(function(e) {
+    $('#registration_password').keyup(function(e) {
       var password = e.target.value
 
       var passedRules = checkPasswordRules(password)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,45 +8,18 @@ class UsersController < AuthenticatedController
     if current_user.present? && !current_user.guest?
       redirect_to dashboard_path
     end
-    @user = User.new
+    @registration = Registration.new
   end
 
   def create
-    if current_user
-      @user = current_user
-      @user.assign_attributes(user_params)
-      @user.guest = false
-    elsif params[:google_id_token].present?
-      @user = User.new
-      @user.skip_password_validation = true
-      google_identity = GoogleSignIn::Identity.new(params[:google_id_token])
-      google_id = google_identity.user_id
-      email = google_identity.email_address
-      name = google_identity.name
+    valid_params  = params[:google_id_token].present? ? params : registration_params
+    @registration = Registration.new(valid_params, current_user || User.new)
 
-      @user.assign_attributes({
-        name: name,
-        email: email,
-        google_id: google_id
-      })
-
-      @user.save
-    else
-      @user = User.new(user_params)
-    end
-
-    if params[:user].present?
-      @user.password_confirmation = user_params[:password]
-    end
-    @user.timezone = Time.zone.tzinfo.name
-
-    valid = @user.save && create_customer_and_subscription
-
-    if valid
-      login(@user)
+    if @registration.save
+      login(@registration.user)
       redirect_to welcome_path
     else
-      flash[:error] = @user.errors.full_messages.join(', ')
+      flash[:error] = @registration.errors.full_messages.join(', ')
       redirect_to new_user_path
     end
   end
@@ -107,17 +80,6 @@ class UsersController < AuthenticatedController
 
   private
 
-  def create_customer_and_subscription
-    payment_service = PaymentService.new({ email: @user.email })
-
-    customer = payment_service.create_customer
-    @user.update(stripe_customer_id: customer.id)
-
-    payment_service = PaymentService.new({ stripe_customer_id: @user.stripe_customer_id })
-    subscription = payment_service.create_subscription
-    @user.update(stripe_subscription_id: subscription.id)
-  end
-
   def add_card_to_user
     @payment_service = PaymentService.new({ stripe_customer_id: @user.stripe_customer_id })
 
@@ -130,6 +92,19 @@ class UsersController < AuthenticatedController
 
   def set_user
     @user = current_user
+  end
+
+  def registration_params
+    params.require(:registration).permit(
+      :name,
+      :email,
+      :phone,
+      :email_reminders,
+      :sms_reminders,
+      :track_weekends,
+      :password,
+      :google_id
+    )
   end
 
   def user_params

--- a/app/forms/registration.rb
+++ b/app/forms/registration.rb
@@ -1,0 +1,59 @@
+class Registration
+  include ActiveModel::Model
+
+  attr_accessor *%i(
+    name
+    email
+    password
+    user
+    params
+  )
+
+  delegate :errors, to: :user
+
+  def initialize(params = {}, user = User.new)
+    @params = params
+    @user   = user
+  end
+
+  def save
+    if signing_up_with_google?
+      @user.skip_password_validation = true
+      google_identity = GoogleSignIn::Identity.new(params[:google_id_token])
+      google_id = google_identity.user_id
+      email = google_identity.email_address
+      name = google_identity.name
+
+      @user.assign_attributes({
+        name: name,
+        email: email,
+        google_id: google_id
+      })
+    else
+      @user.assign_attributes(params)
+    end
+
+    @user.guest = false
+    @user.timezone = Time.zone.tzinfo.name
+
+    @user.save && create_customer_and_subscription
+  end
+
+  private
+
+  def signing_up_with_google?
+    params[:google_id_token].present?
+  end
+
+  def create_customer_and_subscription
+    payment_service = PaymentService.new({ email: @user.email })
+
+    customer = payment_service.create_customer
+    @user.update(stripe_customer_id: customer.id)
+
+    payment_service = PaymentService.new({ stripe_customer_id: @user.stripe_customer_id })
+    subscription = payment_service.create_subscription
+    @user.update(stripe_subscription_id: subscription.id)
+  end
+
+end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -16,7 +16,7 @@
       <%= form.hidden_field :google_id_token, id: 'google_id_token' %>
     <% end %>
 
-    <%= form_for @user do |f| %>
+    <%= form_for @registration, url: users_path do |f| %>
       <div class="inputGroup">
         <%= f.label :name %>
         <%= f.text_field :name %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -17,7 +17,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test '#create should set timezone' do
     cookies[:timezone] = "America/Chicago"
     post users_path, params: {
-      user: {
+      registration: {
         email: 'user@example.com',
         password: SecureRandom.hex
       }
@@ -58,7 +58,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     logout
 
     post users_path, params: {
-      user: {
+      registration: {
         email: 'me@g.com',
         name: 'G',
         password: SecureRandom.hex


### PR DESCRIPTION
Because:

When users would try the demo, we weren't accounting for there being
a user in the session that also signs up via google. The `if`
statement would short circuit when it found a `current_user` and ignore
the `google_id_token`.

This:

Extracts a `Registration` form object that cleans up the logic and
fixes the issue above.