### PR TITLE
Allow users to continue planning tomorrow.

### DIFF
--- a/app/controllers/today_controller.rb
+++ b/app/controllers/today_controller.rb
@@ -5,6 +5,11 @@ class TodayController < ApplicationController
   def show
     @week_plan = current_week_plan
     @todo_list = TodoList.today(@user)
+    @button_text, @button_path = if Reflection.today(current_user).present?
+                                   ["Plan for tomorrow", tomorrow_path]
+                                 else
+                                   ["Reflect on your day", reflect_path]
+                                 end
 
     if @todo_list.blank?
       redirect_to new_today_path

--- a/app/controllers/tomorrow_controller.rb
+++ b/app/controllers/tomorrow_controller.rb
@@ -10,7 +10,7 @@ class TomorrowController < AuthenticatedController
              end
 
       if TodoList.tomorrow(current_user).present? ||
-          Reflection.tomorrow(current_user).blank?
+          Reflection.today(current_user).blank?
         flash[:error] = message
         redirect_to path
       end

--- a/app/views/today/show.html.erb
+++ b/app/views/today/show.html.erb
@@ -31,6 +31,6 @@
     </section>
   <% end %>
 
-  <%= link_to 'All done', reflect_path, class: 'finishDayButton button' %>
+  <%= link_to @button_text, @button_path, class: 'finishDayButton button' %>
   <p class="instructions light">Clicking "All done" will take you to the reflection page. You can come back here and edit your todos until tomorrow.</p>
 </section>


### PR DESCRIPTION
Because:

When a user completes their reflection and taken to the tomorrow path,
they may navigate to the dashboard. If they do this, they won't be able
to get back to the `/tomorrow` route.

This:

Makes the button on `today#show` dynamically link to the `/tomorrow`
path if they have already written their reflection.