### PR TITLE
Fix weekend bug.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,12 @@
 module ApplicationHelper
   def today_is_trackable?
-    return true if current_user.track_weekends
+    if current_user.track_weekends?
+      true
+    else
+      today = Time.current
 
-    today = Time.current
-
-    false if today.on_weekend?
+      today.on_weekday?
+    end
   end
 
   def tomorrow_is_trackable?


### PR DESCRIPTION
Because:

The logic of `#today_is_trackable` was returning the wrong boolean when
users had selected that they don't want to track tasks on weekends.

This:

Simplifies the logic and returns the correct boolean.